### PR TITLE
Fix OSX mktemp issue regarding template format.

### DIFF
--- a/scripts/generate_crankfile.sh
+++ b/scripts/generate_crankfile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TMP=`mktemp -d -t crank`
+TMP=`mktemp -d -t crank.XXX`
 
 cp crank.d/* $TMP
 


### PR DESCRIPTION
mktemp: too few X's in template ‘crank’
